### PR TITLE
removed inexistent registerCommands method in laravel 5.4

### DIFF
--- a/src/LaravelRedisFallbackServiceProvider.php
+++ b/src/LaravelRedisFallbackServiceProvider.php
@@ -54,7 +54,5 @@ class LaravelRedisFallbackServiceProvider extends CacheServiceProvider
         $this->app->singleton('memcached.connector', function() {
             return new MemcachedConnector;
         });
-
-        $this->registerCommands();
     }
 }


### PR DESCRIPTION
Symfony\Component\Debug\Exception\FatalThrowableError: Call to undefined method Xtcat\LaravelRedisFallback\LaravelRedisFallbackServiceProvider::registerCommands() in /vagrant/www/current/vendor/xtcat/laravel-redis-fallback/src/LaravelRedisFallbackServiceProvider.php:58