### PR TITLE
MemcachedConnector does not have namespace defined

### DIFF
--- a/src/LaravelRedisFallbackServiceProvider.php
+++ b/src/LaravelRedisFallbackServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Xtcat\LaravelRedisFallback;
 
 use Illuminate\Cache\CacheServiceProvider;
+use Illuminate\Cache\MemcachedConnector;
 
 /**
  * Redis fallback service provider


### PR DESCRIPTION
The register method is creating an instance of MemcachedConnector but this class is not pressent (forgotten namespace)