### PR TITLE
Fix for php artisan cache:clear to work again

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Note about this fork
+
+This is forked from xcat/laravel-redis-fallback to fix an issue with Laravel versions 5.0 to 5.3 related to the lost functionality of the command: php artisan cache:clear
+
+Xtcat will be creating a new branch to solve it.
+
 # Redis cache fallback for Laravel 5
 
 If you use Redis as cache driver on Laravel 5 and for some reason Redis server became unavailable, you will end up with a Connection Refused exception.
@@ -8,7 +14,7 @@ As soon as Redis come back it will be used again.
 Install LaravelRedisFallback as a Composer package, adding this line to your composer.json:
 
 ```php
-"xtcat/laravel-redis-fallback": "dev-master"
+"guillermobt/laravel-redis-fallback": "dev-master"
 ```
 and update your vendor folder running the ```composer update ``` command.
 
@@ -19,7 +25,7 @@ Replace the default cache service provider:
 	...
 	//'Illuminate\Cache\CacheServiceProvider',
 	...
-	\Xtcat\LaravelRedisFallback\LaravelRedisFallbackServiceProvider::class
+	\guillermobt\LaravelRedisFallback\LaravelRedisFallbackServiceProvider::class
 	...
 )
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "xtcat/laravel-redis-fallback",
+    "name": "guillermobt/laravel-redis-fallback",
     "description": "Laravel 5 redis cache fallback to file",
     "keywords": ["laravel", "laravel5", "cache", "redis", "file"],
     "license": "MIT",
@@ -19,7 +19,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Xtcat\\LaravelRedisFallback\\": "src"
+            "guillermobt\\LaravelRedisFallback\\": "src"
         }
     },
     "minimum-stability": "stable"

--- a/src/LaravelRedisFallback.php
+++ b/src/LaravelRedisFallback.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Xtcat\LaravelRedisFallback;
+namespace guillermobt\LaravelRedisFallback;
 
 use Exception;
 use Illuminate\Cache\CacheManager;

--- a/src/LaravelRedisFallbackFacade.php
+++ b/src/LaravelRedisFallbackFacade.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Xtcat\LaravelRedisFallback;
+namespace guillermobt\LaravelRedisFallback;
 
 use Illuminate\Support\Facades\Facade;
 

--- a/src/LaravelRedisFallbackServiceProvider.php
+++ b/src/LaravelRedisFallbackServiceProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Xtcat\LaravelRedisFallback;
+namespace guillermobt\LaravelRedisFallback;
 
 use Illuminate\Cache\CacheServiceProvider;
 use Illuminate\Cache\MemcachedConnector;

--- a/src/LaravelRedisFallbackServiceProvider.php
+++ b/src/LaravelRedisFallbackServiceProvider.php
@@ -5,6 +5,7 @@ namespace Xtcat\LaravelRedisFallback;
 use Illuminate\Cache\CacheServiceProvider;
 use Illuminate\Cache\MemcachedConnector;
 use Illuminate\Foundation\AliasLoader;
+use Illuminate\Cache\Console\ClearCommand;
 
 /**
  * Redis fallback service provider
@@ -56,5 +57,21 @@ class LaravelRedisFallbackServiceProvider extends CacheServiceProvider
         $this->app->singleton('memcached.connector', function () {
             return new MemcachedConnector;
         });
+        
+        $this->registerCommands();
+    }
+    
+    /**
+     * Register the cache related console commands.
+     *
+     * @return void
+     */
+    public function registerCommands()
+    {
+        $this->app->singleton('command.cache.clear', function ($app) {
+            return new ClearCommand($app['cache']);
+        });
+
+        $this->commands('command.cache.clear');
     }
 }

--- a/src/LaravelRedisFallbackServiceProvider.php
+++ b/src/LaravelRedisFallbackServiceProvider.php
@@ -58,7 +58,9 @@ class LaravelRedisFallbackServiceProvider extends CacheServiceProvider
             return new MemcachedConnector;
         });
         
-        $this->registerCommands();
+        if (floatval(\App::version()) < 5.4) {
+            $this->registerCommands();
+        }
     }
     
     /**


### PR DESCRIPTION
Fixes the "CommandNotFoundException" error when you try to clear the cache with:
php artisan cache:clear

